### PR TITLE
Disable link prefetching in menu topbar

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -227,6 +227,7 @@ export function TopBar({ navItems = defaultNavItems }: TopBarProps) {
                 <Link
                   key={item.href}
                   href={item.href}
+                  prefetch={false}
                   onClick={(e) => {
                     if (loading) {
                       e.preventDefault()


### PR DESCRIPTION
Disable prefetching for links in the topbar menu to improve performance and reduce unnecessary network requests.